### PR TITLE
Fixed API failure when adding a trailing slash to zendesk_url

### DIFF
--- a/zendesk/zendesk.py
+++ b/zendesk/zendesk.py
@@ -88,6 +88,8 @@ class Zendesk(object):
         self.data = None
 
         # Set attributes necessary for API
+        if zendesk_url[-1:] == "/": # API will fail if there's a trailing slash
+            zendesk_url = zendesk_url[:-1]
         self.zendesk_url = zendesk_url
         self.zendesk_username = zendesk_username
         if use_api_token:


### PR DESCRIPTION
When your API url is like "https://example.zendesk.com/" with a trailing slash, API calls (such as create_ticket) will fail with a 404 error message.

This commit changes the behavior of the library to check for a trailing slash and if one is found, remove it silently.
