### PR TITLE
Fixed update and delete organization endpoint for v2 API

### DIFF
--- a/zendesk/endpoints_v2.py
+++ b/zendesk/endpoints_v2.py
@@ -317,28 +317,28 @@ mapping_table = {
     },
 
     # Organizations
-    'list_organzations': {
+    'list_organizations': {
         'path': '/organizations.json',
         'method': 'GET',
     },
-    'autocomplete_organzations': {
+    'autocomplete_organizations': {
         'path': '/organizations/autocomplete.json',
         'valid_params': ['name'],
         'method': 'GET',
     },
-    'show_organzation': {
+    'show_organization': {
         'path': '/organizations/{{organization_id}}.json',
         'method': 'GET',
     },
-    'create_organzation': {
+    'create_organization': {
         'path': '/organizations.json',
         'method': 'POST',
     },
-    'update_organzation': {
+    'update_organization': {
         'path': '/organizations/{{organization_id}}.json',
         'method': 'PUT',
     },
-    'delete_organzation': {
+    'delete_organization': {
         'path': '/organizations/{{organization_id}}.json',
         'method': 'DELETE',
     },


### PR DESCRIPTION
According to the Zendesk API docs:

http://developer.zendesk.com/documentation/rest_api/organizations.html#updating-organizations

The Updating and Deleting Organizations methods require an organization ID to be passed in the URL.
