### PR TITLE
extend valid_params for search to include sort_by

### DIFF
--- a/zendesk/endpoints_v2.py
+++ b/zendesk/endpoints_v2.py
@@ -354,7 +354,7 @@ mapping_table = {
     # Search
     'search': {
         'path': '/search.json',
-        'valid_params': ['query'],
+        'valid_params': ['query','sort_by'],
         'method': 'GET',
     },
     'anonymous_search': {


### PR DESCRIPTION
been using in production for a while e.g. search(query='ticket+sort:desc', page=page, sort_by='created_at')
